### PR TITLE
Ignore blank and null entries in PATH search for mvn/gradle execs

### DIFF
--- a/src/main/java/com/ibm/cldk/utils/BuildProject.java
+++ b/src/main/java/com/ibm/cldk/utils/BuildProject.java
@@ -29,7 +29,7 @@ public class BuildProject {
      * @return the maven command
      */
     public static String getMavenCommand() {
-        String mvnSystemCommand = Arrays.stream(System.getenv("PATH").split(System.getProperty("path.separator"))).map(path -> new File(path, System.getProperty("os.name").toLowerCase().contains("windows") ? "mvn.cmd" : "mvn")).filter(File::exists).findFirst().map(File::getAbsolutePath).orElse(null);
+        String mvnSystemCommand = Arrays.stream(System.getenv("PATH").split(System.getProperty("path.separator"))).filter(Predicate.not(String::isBlank)).filter(Predicate.not(String::isEmpty)).map(path -> new File(path, System.getProperty("os.name").toLowerCase().contains("windows") ? "mvn.cmd" : "mvn")).filter(File::exists).findFirst().map(File::getAbsolutePath).orElse(null);
         File mvnWrapper = System.getProperty("os.name").toLowerCase().contains("windows") ? new File(projectRootPom, "mvnw.cmd") : new File(projectRootPom, "mvnw");
         return commandExists(mvnWrapper.getAbsoluteFile()).getKey() ? mvnWrapper.getAbsoluteFile().toString() : mvnSystemCommand;
     }
@@ -40,7 +40,7 @@ public class BuildProject {
      * @return the gradle command
      */
     public static String getGradleCommand() {
-        String gradleSystemCommand = Arrays.stream(System.getenv("PATH").split(System.getProperty("path.separator"))).map(path -> new File(path, System.getProperty("os.name").toLowerCase().contains("windows") ? "gradle.bat" : "gradle")).filter(File::exists).findFirst().map(File::getAbsolutePath).orElse(null);
+        String gradleSystemCommand = Arrays.stream(System.getenv("PATH").split(System.getProperty("path.separator"))).filter(Predicate.not(String::isBlank)).filter(Predicate.not(String::isEmpty)).map(path -> new File(path, System.getProperty("os.name").toLowerCase().contains("windows") ? "gradle.bat" : "gradle")).filter(File::exists).findFirst().map(File::getAbsolutePath).orElse(null);
         File gradleWrapper = System.getProperty("os.name").toLowerCase().contains("windows") ? new File(projectRootPom, "gradlew.bat") : new File(projectRootPom, "gradlew");
 
         return commandExists(gradleWrapper.getAbsoluteFile()).getKey() ? gradleWrapper.getAbsoluteFile()    .toString() : gradleSystemCommand;


### PR DESCRIPTION
## Motivation and Context
With a null PATH entry on Windows finding the mvn command resolves to absolute path: "C:\mvn.cmd" which does not exist for me, so the dependency lib download fails.

Error log msgs like:

```
[36m2025-02-25T10:27:24.866896[0m[31m	[ERROR]	[0mCould not verify that C:\mvn.cmd exists
[36m2025-02-25T10:27:24.932447400[0m[33m	[WARN]	[0mFailed to download library dependencies of project
```

I noticed this on v1.1.0 but looking at the code it appears to exist in the main branch as well.

## How Has This Been Tested?

Tested with an empty PATH entry on Windows

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
Haven't tested

## Additional context

I did a bit of searching to try to understand if an empty PATH entry should be considered meaningful, and found some leads suggesting it should mean the current directory.  I didn't follow up on this though.    

We wouldn't want to use `map(File::getAbsolutePath)` if we wanted to find something in the current directory, so that would require a different solution.  It might still be better to filter this case out until/unless it is clear we want to include it.
