### PR TITLE
Lexical preserving code attribute and new code list start attribute in callables

### DIFF
--- a/src/main/java/com/ibm/cldk/SymbolTable.java
+++ b/src/main/java/com/ibm/cldk/SymbolTable.java
@@ -339,7 +339,7 @@ public class SymbolTable {
                         return throwStmt.asThrowStmt().getExpression().toString();
                     }
                 }).collect(Collectors.toList()));
-        initializationBlock.setCode(LexicalPreservingPrinter.setup(initializerDeclaration.getBody()).toString());
+        initializationBlock.setCode(LexicalPreservingPrinter.print(initializerDeclaration.getBody()));
         initializationBlock.setStartLine(
                 initializerDeclaration.getRange().isPresent() ? initializerDeclaration.getRange().get().begin.line
                         : -1);
@@ -563,7 +563,7 @@ public class SymbolTable {
         callableNode.setStartLine(callableDecl.getRange().isPresent() ? callableDecl.getRange().get().begin.line : -1);
         callableNode.setEndLine(callableDecl.getRange().isPresent() ? callableDecl.getRange().get().end.line : -1);
         callableNode.setReferencedTypes(getReferencedTypes(body));
-        callableNode.setCode(body.isPresent() ? LexicalPreservingPrinter.setup(body.get()).toString() : "");
+        callableNode.setCode(body.isPresent() ? LexicalPreservingPrinter.print(body.get()) : "");
         callableNode.setCodeStartLine(body.isPresent()? body.get().getBegin().get().line : -1);
 
         callableNode.setAccessedFields(getAccessedFields(body, classFields, typeName));
@@ -1090,7 +1090,7 @@ public class SymbolTable {
         for (SourceRoot sourceRoot : projectRoot.getSourceRoots()) {
             for (ParseResult<CompilationUnit> parseResult : sourceRoot.tryToParse()) {
                 if (parseResult.isSuccessful()) {
-                    CompilationUnit compilationUnit = parseResult.getResult().get();
+                    CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(parseResult.getResult().get());
                     symbolTable.put(compilationUnit.getStorage().get().getPath().toString(),
                             processCompilationUnit(compilationUnit));
                 } else {
@@ -1116,7 +1116,7 @@ public class SymbolTable {
         JavaParser javaParser = new JavaParser(parserConfiguration);
         ParseResult<CompilationUnit> parseResult = javaParser.parse(code);
         if (parseResult.isSuccessful()) {
-            CompilationUnit compilationUnit = parseResult.getResult().get();
+            CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(parseResult.getResult().get());
             Log.debug("Successfully parsed code. Now processing compilation unit");
             symbolTable.put("<pseudo-path>", processCompilationUnit(compilationUnit));
         } else {
@@ -1158,7 +1158,7 @@ public class SymbolTable {
         for (Path javaFilePath : javaFilePaths) {
             ParseResult<CompilationUnit> parseResult = javaParser.parse(javaFilePath);
             if (parseResult.isSuccessful()) {
-                CompilationUnit compilationUnit = parseResult.getResult().get();
+                CompilationUnit compilationUnit = LexicalPreservingPrinter.setup(parseResult.getResult().get());
                 System.out.println("Successfully parsed file: " + javaFilePath.toString());
                 symbolTable.put(compilationUnit.getStorage().get().getPath().toString(),
                         processCompilationUnit(compilationUnit));

--- a/src/main/java/com/ibm/cldk/SymbolTable.java
+++ b/src/main/java/com/ibm/cldk/SymbolTable.java
@@ -16,38 +16,23 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.github.javaparser.*;
+import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc;
 import com.github.javaparser.ast.stmt.*;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import com.ibm.cldk.entities.*;
 import com.ibm.cldk.javaee.EntrypointsFinderFactory;
 import org.apache.commons.lang3.tuple.Pair;
 
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.ParseResult;
-import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.Problem;
-import com.github.javaparser.ast.AccessSpecifier;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.expr.AnnotationExpr;
-import com.github.javaparser.ast.expr.AssignExpr;
-import com.github.javaparser.ast.expr.CastExpr;
-import com.github.javaparser.ast.expr.ConditionalExpr;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.type.Type;
-import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
-import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
@@ -57,17 +42,6 @@ import com.github.javaparser.utils.ProjectRoot;
 import com.github.javaparser.utils.SourceRoot;
 import com.google.common.collect.Table;
 import com.google.common.collect.Tables;
-import com.ibm.cldk.entities.CRUDOperation;
-import com.ibm.cldk.entities.CRUDQuery;
-import com.ibm.cldk.entities.CallSite;
-import com.ibm.cldk.entities.Callable;
-import com.ibm.cldk.entities.EnumConstant;
-import com.ibm.cldk.entities.Field;
-import com.ibm.cldk.entities.InitializationBlock;
-import com.ibm.cldk.entities.JavaCompilationUnit;
-import com.ibm.cldk.entities.ParameterInCallable;
-import com.ibm.cldk.entities.RecordComponent;
-import com.ibm.cldk.entities.VariableDeclaration;
 import com.ibm.cldk.javaee.CRUDFinderFactory;
 import com.ibm.cldk.javaee.utils.enums.CRUDOperationType;
 import com.ibm.cldk.javaee.utils.enums.CRUDQueryType;
@@ -365,7 +339,7 @@ public class SymbolTable {
                         return throwStmt.asThrowStmt().getExpression().toString();
                     }
                 }).collect(Collectors.toList()));
-        initializationBlock.setCode(initializerDeclaration.getBody().toString());
+        initializationBlock.setCode(LexicalPreservingPrinter.setup(initializerDeclaration.getBody()).toString());
         initializationBlock.setStartLine(
                 initializerDeclaration.getRange().isPresent() ? initializerDeclaration.getRange().get().begin.line
                         : -1);
@@ -589,7 +563,8 @@ public class SymbolTable {
         callableNode.setStartLine(callableDecl.getRange().isPresent() ? callableDecl.getRange().get().begin.line : -1);
         callableNode.setEndLine(callableDecl.getRange().isPresent() ? callableDecl.getRange().get().end.line : -1);
         callableNode.setReferencedTypes(getReferencedTypes(body));
-        callableNode.setCode(body.isPresent() ? body.get().toString() : "");
+        callableNode.setCode(body.isPresent() ? LexicalPreservingPrinter.setup(body.get()).toString() : "");
+        callableNode.setCodeStartLine(body.isPresent()? body.get().getBegin().get().line : -1);
 
         callableNode.setAccessedFields(getAccessedFields(body, classFields, typeName));
         callableNode.setCallSites(getCallSites(body));

--- a/src/main/java/com/ibm/cldk/entities/Callable.java
+++ b/src/main/java/com/ibm/cldk/entities/Callable.java
@@ -70,6 +70,9 @@ public class Callable {
     /** The ending line number of the callable entity in the source file. */
     private int endLine;
 
+    /** The starting line number of the callable code in the source file. */
+    private int codeStartLine;
+
     /** The return type of the callable entity. */
     private String returnType = null;
 


### PR DESCRIPTION

<!-- Provide a brief summary of your changes -->
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

This PR makes two changes. First, it updates the code attribute for callables and initializers to be lexical preserving (thus, not discarding blank lines), which ensures that relative line numbers within a code block with respect to the start of the code block can be used accurately. Second, the PR adds the `codeStartLine` attribute to callables so that determining the start line of a code block does not require the application of heuristics on callable start line handling the formatting of callable annotations and declaration.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tested with sample code and checked the updates attributes.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
